### PR TITLE
Feature pipe stdout from execution cell

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,19 @@ The output will be the generated SVG UML diagram using the plantuml.jar on your 
     Bob --> Alice: Authentication Response
     @enduml
 
+To specify an alternative plantuml jar path one can also use the `-p` switch:
+
+::
+
+    %%plantuml
+
+    @startuml --jar -p /usr/share/plantuml/plantuml.jar
+    Alice -> Bob: Authentication Request
+    Bob --> Alice: Authentication Response
+    @enduml
+
+Further one can use the `PLANTUMLPATH` environment variable to set the
+plantuml.jar path.
 
 By default, the magic removes the intermediate (``tmp.uml``) and target
 (``tmp.svg``) files. However, if you enter a name in the ``%%plantuml``
@@ -86,3 +99,5 @@ example,
     @enduml
 
 generates and retains ``auth.uml`` and ``auth.svg``.
+
+

--- a/README.rst
+++ b/README.rst
@@ -74,9 +74,9 @@ To specify an alternative plantuml jar path one can also use the `-p` switch:
 
 ::
 
-    %%plantuml
+    %%plantuml --jar -p /usr/share/plantuml/plantuml.jar
 
-    @startuml --jar -p /usr/share/plantuml/plantuml.jar
+    @startuml 
     Alice -> Bob: Authentication Request
     Bob --> Alice: Authentication Response
     @enduml

--- a/iplantuml/__init__.py
+++ b/iplantuml/__init__.py
@@ -67,6 +67,14 @@ def plantuml_web(*file_names, **kwargs):
 
     return _exec_and_get_paths(cmd, file_names)
 
+@register_cell_magic
+def plantuml_pythoncode(line, cell):
+    from io import StringIO
+    import sys
+    old_stdout = sys.stdoutsys.stdout = mystdout = StringIO()
+    exec(cell)
+    sys.stdout = old_stdout
+    plantuml(line, mystdout.getvalue())
 
 @register_cell_magic
 def plantuml(line, cell):

--- a/iplantuml/__init__.py
+++ b/iplantuml/__init__.py
@@ -48,8 +48,8 @@ class IPlantUMLMagics(Magics):
             jar file resides.
         :return: the path to the generated SVG UML diagram.
         """
-    	plantuml_path = os.environ.get('PLANTUMLPATH',PLANTUMLPATH) 
-    	plantuml_path = kwargs.get('plantuml_path', plantuml_path)
+        plantuml_path = os.environ.get('PLANTUMLPATH',PLANTUMLPATH) 
+        plantuml_path = kwargs.get('plantuml_path', plantuml_path)
         
         cmd = ["java",
                "-splash:no",
@@ -129,36 +129,5 @@ class IPlantUMLMagics(Magics):
                 if os.path.exists(svg_path):
                     os.unlink(svg_path)
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-j", "--jar", action="store_true",
-                        help="render using plantuml.jar (default is plantweb)")
-    parser.add_argument("-n", "--name", type=str, default=None,
-                        help="persist as <name>.uml and <name>.svg after rendering")
-    parser.add_argument("-p", "--plantuml-path", default=None,
-                        help="specify PlantUML jar path (default={})".format(PLANTUMLPATH))
-    args = parser.parse_args(line.split() if line else "")
-    retain = args.name is not None
-    base_name = args.name or str(uuid.uuid4())
-    use_web = not (args.jar or args.plantuml_path)
-
-    uml_path = base_name + ".uml"
-    with open(uml_path, 'w') as fp:
-        fp.write(cell)
-
-    try:
-        output = None
-        if use_web:
-            output = plantuml_web(uml_path)
-        else:
-            plantuml_path = os.path.abspath(args.plantuml_path or PLANTUMLPATH)
-            output = plantuml_exec(uml_path, plantuml_path=plantuml_path)
-        svg_name = output[0]
-        return SVG(filename=svg_name)
-    finally:
-        if not retain:
-            if os.path.exists(uml_path):
-                os.unlink(uml_path)
-            svg_path = base_name + ".svg"
-            if os.path.exists(svg_path):
-                os.unlink(svg_path)
-==== BASE ====
+ip = get_ipython()
+ip.register_magics(IPlantUMLMagics)

--- a/iplantuml/__init__.py
+++ b/iplantuml/__init__.py
@@ -43,7 +43,8 @@ def plantuml_exec(*file_names, **kwargs):
         jar file resides.
     :return: the path to the generated SVG UML diagram.
     """
-    plantuml_path = kwargs.get('plantuml_path', PLANTUMLPATH)
+    plantuml_path = os.environ.get('PLANTUMLPATH',PLANTUMLPATH) 
+    plantuml_path = kwargs.get('plantuml_path', plantuml_path)
 
     cmd = ["java",
            "-splash:no",

--- a/iplantuml/__init__.py
+++ b/iplantuml/__init__.py
@@ -2,10 +2,13 @@ import argparse
 import os
 import subprocess
 import uuid
+import sys
+from io import StringIO
 
-from IPython.core.magic import register_cell_magic
+
 from IPython.display import SVG
 
+from IPython.core.magic import (Magics, magics_class, cell_magic)
 import plantweb  # dummy import to ensure plantweb module is present
 
 
@@ -27,95 +30,103 @@ __email__ = "jbn@abreka.com"
 
 PLANTUMLPATH = '/usr/local/bin/plantuml.jar'
 
+@magics_class
+class IPlantUMLMagics(Magics):
 
-def _exec_and_get_paths(cmd, file_names):
-    subprocess.check_call(cmd, shell=False, stderr=subprocess.STDOUT)
-
-    return [os.path.splitext(f)[0] + ".svg" for f in file_names]
-
-
-def plantuml_exec(*file_names, **kwargs):
-    """
-    Given a list of UML documents, generate corresponding SVG diagrams.
-
-    :param file_names: the filenames of the documents for parsing by PlantUML.
-    :param kwargs: optionally `plantuml_path`, indicating where the PlantUML
-        jar file resides.
-    :return: the path to the generated SVG UML diagram.
-    """
-    plantuml_path = kwargs.get('plantuml_path', PLANTUMLPATH)
-
-    cmd = ["java",
-           "-splash:no",
-           "-jar", plantuml_path,
-           "-tsvg"] + list(file_names)
-
-    return _exec_and_get_paths(cmd, file_names)
+    def _exec_and_get_paths(self, cmd, file_names):
+        subprocess.check_call(cmd, shell=False, stderr=subprocess.STDOUT)
+        
+        return [os.path.splitext(f)[0] + ".svg" for f in file_names]
 
 
-def plantuml_web(*file_names, **kwargs):
-    """
-    Given a list of UML documents, generate corresponding SVG diagrams, using
-    PlantUML's web service via the plantweb module.
+    def plantuml_exec(self, *file_names, **kwargs):
+        """
+        Given a list of UML documents, generate corresponding SVG diagrams.
 
-    :param file_names: the filenames of the documents for parsing by PlantUML.
-    :return: the path to the generated SVG UML diagram.
-    """
-    cmd = ["plantweb",
-           "--format",
-           "auto"] + list(file_names)
+        :param file_names: the filenames of the documents for parsing by PlantUML.
+        :param kwargs: optionally `plantuml_path`, indicating where the PlantUML
+            jar file resides.
+        :return: the path to the generated SVG UML diagram.
+        """
+        plantuml_path = kwargs.get('plantuml_path', PLANTUMLPATH)
+        
+        cmd = ["java",
+               "-splash:no",
+               "-jar", plantuml_path,
+               "-tsvg"] + list(file_names)
 
-    return _exec_and_get_paths(cmd, file_names)
+        return self._exec_and_get_paths(cmd, file_names)
 
-@register_cell_magic
-def plantuml_pythoncode(line, cell):
-    from io import StringIO
-    import sys
-    old_stdout = sys.stdoutsys.stdout = mystdout = StringIO()
-    exec(cell)
-    sys.stdout = old_stdout
-    plantuml(line, mystdout.getvalue())
 
-@register_cell_magic
-def plantuml(line, cell):
-    """
-    Generate and inline the SVG portrayal of the given PlantUML UML spec.
+    def plantuml_web(self, *file_names, **kwargs):
+        """
+        Given a list of UML documents, generate corresponding SVG diagrams, using
+        PlantUML's web service via the plantweb module.
 
-    :param line: if not empty, it is the base file name to give to the
-        serialized cell contents and the generated SVG files.
-    :param cell: the PlantUML language UML specification.
-    :return: a IPython SVG object for the diagram or None given error.
-    """
+        :param file_names: the filenames of the documents for parsing by PlantUML.
+        :return: the path to the generated SVG UML diagram.
+        """
+        cmd = ["plantweb",
+               "--format",
+               "auto"] + list(file_names)
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-j", "--jar", action="store_true",
-                        help="render using plantuml.jar (default is plantweb)")
-    parser.add_argument("-n", "--name", type=str, default=None,
-                        help="persist as <name>.uml and <name>.svg after rendering")
-    parser.add_argument("-p", "--plantuml-path", default=None,
-                        help="specify PlantUML jar path (default={})".format(PLANTUMLPATH))
-    args = parser.parse_args(line.split() if line else "")
-    retain = args.name is not None
-    base_name = args.name or str(uuid.uuid4())
-    use_web = not (args.jar or args.plantuml_path)
+        return self._exec_and_get_paths(cmd, file_names)
 
-    uml_path = base_name + ".uml"
-    with open(uml_path, 'w') as fp:
-        fp.write(cell)
 
-    try:
-        output = None
-        if use_web:
-            output = plantuml_web(uml_path)
-        else:
-            plantuml_path = os.path.abspath(args.plantuml_path or PLANTUMLPATH)
-            output = plantuml_exec(uml_path, plantuml_path=plantuml_path)
-        svg_name = output[0]
-        return SVG(filename=svg_name)
-    finally:
-        if not retain:
-            if os.path.exists(uml_path):
-                os.unlink(uml_path)
-            svg_path = base_name + ".svg"
-            if os.path.exists(svg_path):
-                os.unlink(svg_path)
+    @cell_magic
+    def plantuml(self, line, cell):
+        """
+        Generate and inline the SVG portrayal of the given PlantUML UML spec.
+
+        :param line: if not empty, it is the base file name to give to the
+            serialized cell contents and the generated SVG files.
+        :param cell: the PlantUML language UML specification.
+        :return: a IPython SVG object for the diagram or None given error.
+        """
+        parser = argparse.ArgumentParser()
+        
+        parser.add_argument("-j", "--jar", action="store_true",
+                            help="render using plantuml.jar (default is plantweb)")
+        parser.add_argument("-n", "--name", type=str, default=None,
+                            help="persist as <name>.uml and <name>.svg after rendering")
+        parser.add_argument("-p", "--plantuml-path", default=None,
+                            help="specify PlantUML jar path (default={})".format(PLANTUMLPATH))
+        parser.add_argument("-i", "--pipe", action='store_true',
+                            help="Execute the cell python and pipe the output (as plantuml format) to plantuml")
+        args = parser.parse_args(line.split() if line else "")
+        retain = args.name is not None
+        base_name = args.name or str(uuid.uuid4())
+        use_web = not (args.jar or args.plantuml_path)
+
+        uml_path = base_name + ".uml"
+        with open(uml_path, 'w') as fp:
+            if args.pipe:
+                old_stdout = sys.stdout
+                sys.stdout = my_stdout = StringIO()
+                self.shell.ex(cell)
+                sys.stdout = old_stdout
+                uml_file_content = my_stdout.getvalue()
+                my_stdout.close()
+            else:
+                uml_file_content = cell
+            fp.write(uml_file_content)
+
+        try:
+            output = None
+            if use_web:
+                output = self.plantuml_web(uml_path)
+            else:
+                plantuml_path = os.path.abspath(args.plantuml_path or PLANTUMLPATH)
+                output = self.plantuml_exec(uml_path, plantuml_path=plantuml_path)
+            svg_name = output[0]
+            return SVG(filename=svg_name)
+        finally:
+            if not retain:
+                if os.path.exists(uml_path):
+                    os.unlink(uml_path)
+                svg_path = base_name + ".svg"
+                if os.path.exists(svg_path):
+                    os.unlink(svg_path)
+
+ip = get_ipython()
+ip.register_magics(IPlantUMLMagics)


### PR DESCRIPTION
I change a lot of code to add the pipe feature.

This example shows the new feature (and argument -i or --pipe):
```json
{
 "cells": [
  {
   "cell_type": "code",
   "execution_count": null,
   "metadata": {},
   "outputs": [],
   "source": [
    "import iplantuml"
   ]
  },
  {
   "cell_type": "code",
   "execution_count": null,
   "metadata": {},
   "outputs": [],
   "source": [
    "TEMPLATE = \"\"\"\n",
    "@startuml\n",
    "\"{person1}\" -> \"{person2}\": \"{send}\"\n",
    "\"{person1}\" <- \"{person2}\": \"{receive}\"\n",
    "@enduml\n",
    "\"\"\""
   ]
  },
  {
   "cell_type": "code",
   "execution_count": null,
   "metadata": {},
   "outputs": [],
   "source": [
    "%%plantuml --pipe\n",
    "\n",
    "print(TEMPLATE.format(person1='Me', person2='Trump',\n",
    "                     send='Give me a 1 billion dolars.',\n",
    "                     receive='I send you 10 billions dolars.'))"
   ]
  },
  {
   "cell_type": "code",
   "execution_count": null,
   "metadata": {},
   "outputs": [],
   "source": []
  }
 ],
 "metadata": {
  "kernelspec": {
   "display_name": "Python 3",
   "language": "python",
   "name": "python3"
  },
  "language_info": {
   "codemirror_mode": {
    "name": "ipython",
    "version": 3
   },
   "file_extension": ".py",
   "mimetype": "text/x-python",
   "name": "python",
   "nbconvert_exporter": "python",
   "pygments_lexer": "ipython3",
   "version": "3.6.8"
  }
 },
 "nbformat": 4,
 "nbformat_minor": 2
}
```